### PR TITLE
tensorflow-io-gcs-filesystem==0.37.1 호환성 문제

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -145,7 +145,7 @@ sympy==1.13.1
 tensorboard==2.17.1
 tensorboard-data-server==0.7.2
 tensorflow==2.17.0
-tensorflow-io-gcs-filesystem==0.37.1
+
 termcolor==2.5.0
 terminado==0.18.1
 threadpoolctl==3.5.0


### PR DESCRIPTION
파이썬 3.10버전으로 requirements 실행할 때
tensorflow-io-gcs-filesystem==0.37.1 설치가 안되어서 삭제 후 진행, 0.31 자동으로 설치됨